### PR TITLE
Generic Emulator Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 The HDR Launcher, this time written in the React framework with TypeScript with both a Switch and Desktop backend.
 Switch backend runs as a skyline plugin using skyline-web.
-Desktop application is an electron app for use with Ryujinx.
+Desktop application is an electron app for use with Emulators.
 
 Releases can be found on the [releases page](https://github.com/techyCoder81/hdr-launcher-react/releases), or bundled as part of HDR [Beta](https://github.com/HDR-Development/HDR-Releases/releases) and [Nightly](https://github.com/HDR-Development/HDR-Nightlies/releases) full packages.
 

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -5,15 +5,12 @@ export default class Config {
 
   ryuPath: string = '';
 
-  romPath: string = '';
-
   sdcardPath: string = '';
 
   private static createFile() {
     if (!fs.existsSync(Config.CONFIG_FILE)) {
       const configStr = JSON.stringify({
         ryuPath: null,
-        romPath: null,
         sdcardPath: null,
       });
       fs.writeFileSync(Config.CONFIG_FILE, configStr);
@@ -30,17 +27,6 @@ export default class Config {
 
   private static saveConfig(config: Config) {
     fs.writeFileSync(Config.CONFIG_FILE, JSON.stringify(config));
-  }
-
-  static getRomPath() {
-    const config = Config.readFile();
-    return config.romPath;
-  }
-
-  static setRomPath(path: string) {
-    const config = Config.readFile();
-    config.romPath = path;
-    Config.saveConfig(config);
   }
 
   static getRyuPath() {

--- a/src/main/request_handler.ts
+++ b/src/main/request_handler.ts
@@ -17,6 +17,7 @@ import * as Process from 'child_process';
 import * as net from 'net';
 import { mainWindow } from './main';
 import Config from './config';
+import * as os from 'os';
 
 const webrequest = require('request');
 const explorer = require('open-file-explorer');
@@ -112,7 +113,7 @@ async function handleInner(
       );
       break;
     case 'get_platform':
-      resolve(new Responses.OkOrError(true, 'Ryujinx', request.id));
+      resolve(new Responses.OkOrError(true, 'Emulator', request.id));
       break;
     case 'get_sdcard_root':
       resolve(
@@ -356,7 +357,11 @@ async function handleInner(
       }
     case 'open_mod_manager':
       try {
-        explorer(`${Config.getSdcardPath()}ultimate/mods/`, (err: any) => {
+        let mods_path = 'ultimate/mods/';
+        if (os.platform() == 'win32') {
+          mods_path = 'ultimate\\mods\\';
+        }
+        explorer(`${Config.getSdcardPath()}${mods_path}`, (err: any) => {
           if (err) {
             resolve(new Responses.OkOrError(false, err.toString(), request.id));
           } else {
@@ -398,7 +403,7 @@ async function handleInner(
         // read the given file path
         const file: string = request.arguments[0];
 
-        // on ryujinx, if the folder name exists, then its enabled
+        // on emulator, if the folder name exists, then its enabled
         resolve(
           new Responses.OkOrError(
             true,
@@ -811,10 +816,10 @@ async function handleInner(
       // play the game
       // resolve(new Responses.OkOrError(true, "starting the game...", request.id));
       let command = path.normalize(
-        `${Config.getRyuPath()} "${Config.getRomPath()}"`
+        `${Config.getRyuPath()}`
       );
       if (process.platform == 'win32') {
-        command = `cmd /C ""${Config.getRyuPath()}" a "${Config.getRomPath()}""`;
+        command = `cmd /C ""${Config.getRyuPath()}""`;
       }
       console.log(`Starting the game, with command: ${command}`);
       Process.exec(command, (result) => {

--- a/src/renderer/operations/backend.ts
+++ b/src/renderer/operations/backend.ts
@@ -56,7 +56,7 @@ export class Backend extends DefaultMessenger {
    * @returns the platform name
    */
   public static platformName() {
-    return this.isNode() ? 'Ryujinx' : 'Switch';
+    return this.isNode() ? 'Emulator' : 'Switch';
   }
 
   private static platform: string;

--- a/src/renderer/operations/verify.ts
+++ b/src/renderer/operations/verify.ts
@@ -262,7 +262,7 @@ export default async function verify(
           .catch((e) => console.error(e));
       }
 
-      // launcher nro is unnecessary on ryujinx and will actually cause a crash (for the old launcher)
+      // launcher nro is unnecessary on emulator and will actually cause a crash (for the old launcher)
       if (
         Backend.isNode() &&
         (await backend.fileExists(`${sdroot + plugins_dir}/hdr-launcher.nro`))
@@ -272,7 +272,7 @@ export default async function verify(
           .then((str) => console.debug('deleted old launcher'))
           .catch((e) =>
             alert(
-              'Failed to delete old launcher nro for Ryujinx, which will likely crash on game boot.'
+              'Failed to delete old launcher nro for emulator, which will likely crash on game boot.'
             )
           );
       }

--- a/switch/Cargo.lock
+++ b/switch/Cargo.lock
@@ -317,6 +317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6823e4bff6dee10a75dfee95afe1c5a7f93a1b99a20013663e0cb04b3a64f867"
 
 [[package]]
+name = "libc-nnsdk"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99102e4669e461772fcdfeb04ce9dec03c5fade700a3c12b1a4c2a27d97e9b68"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,9 +426,9 @@ source = "git+https://github.com/skyline-rs/rust-native-tls?branch=switch#f202fc
 dependencies = [
  "lazy_static",
  "libc",
- "libc-nnsdk",
+ "libc-nnsdk 0.2.0",
  "log",
- "nnsdk 0.2.1",
+ "nnsdk 0.3.0",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -443,15 +449,15 @@ name = "nnsdk"
 version = "0.2.0"
 source = "git+https://github.com/Raytwo/nnsdk-rs?branch=account_fs#305075deada1be65827019810469fc0f3d519160"
 dependencies = [
- "libc-nnsdk",
+ "libc-nnsdk 0.2.0",
 ]
 
 [[package]]
 name = "nnsdk"
-version = "0.2.1"
-source = "git+https://github.com/ultimate-research/nnsdk-rs#ec4c77cc2946721f1b815a9ab794241febb68037"
+version = "0.3.0"
+source = "git+https://github.com/ultimate-research/nnsdk-rs#bb0ee1d213393d1eaeb9b380064e97bfada199d1"
 dependencies = [
- "libc-nnsdk",
+ "libc-nnsdk 0.3.0",
 ]
 
 [[package]]
@@ -781,7 +787,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9950fc129490cff3f4755aa523df16aeeb80130699abfc59cc7c6df8fc5802ad"
 dependencies = [
- "libc-nnsdk",
+ "libc-nnsdk 0.2.0",
  "nnsdk 0.2.0",
  "skyline_macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -791,7 +797,7 @@ name = "skyline"
 version = "0.2.1"
 source = "git+https://github.com/ultimate-research/skyline-rs.git#d70df57f243fcb18f168c8ce9dca75f6490d3bf2"
 dependencies = [
- "libc-nnsdk",
+ "libc-nnsdk 0.2.0",
  "nnsdk 0.2.0",
  "skyline_macro 0.2.0 (git+https://github.com/ultimate-research/skyline-rs.git)",
 ]
@@ -865,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "smashnet"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9371bdc9b319f649ca6a7f75ee397eae5247735979632cc39dcfb20ea85152e6"
+checksum = "b2a31891313daacdbddc5c51f4f8f9b457ad2df5be34a06447bd2c2106b29c1d"
 dependencies = [
  "skyline 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/switch/build.rs
+++ b/switch/build.rs
@@ -56,7 +56,7 @@ fn main() -> (){
         .replace("e=>Object.getPrototypeOf(e)", "(e=>Object.getPrototypeOf(e))")
         .replace(".Component{state=yr;", ".Component{")
         .replace("resetErrorBoundary=(...e)=>", "resetErrorBoundary(e)")
-        //.replace("this.isNode() ? \"Ryujinx\" : \"Switch\"", "(this.isNode() ? \"Ryujinx\" : \"Switch\")")
+        //.replace("this.isNode() ? \"Emulator\" : \"Switch\"", "(this.isNode() ? \"Emulator\" : \"Switch\")")
         .replace("\"assets/", "\"");
 
     std::fs::remove_file(JS_FILE_PATH).unwrap();


### PR DESCRIPTION
# Changelog

Removes specialized Ryujinx support in favor of generic Switch emulator support. The HDR Launcher will now ask for just the path to the emulator's executable as well as the emulator's SD Card folder.

Fixes an issue with the launcher on Windows that always caused the user's Documents folder to appear when installing a PR build.