### PR TITLE
Automatically delete launcher nro file if running on PC/Emulator.

### DIFF
--- a/src/renderer/operations/update.ts
+++ b/src/renderer/operations/update.ts
@@ -204,6 +204,21 @@ export async function handleDeletions(
         (p: Progress) => reportProgress(p)
       );
 
+      // check for hdr-launcher.nro and delete it if we're on emulator
+      const platform = await backend.getPlatform();
+      const nroPath = 'atmosphere/contents/01006A800016E000/romfs/skyline/plugins/hdr-launcher.nro';
+      try {
+        if (platform === "Emulator") {
+          const exists = await backend.fileExists(sdroot + nroPath);
+          if (exists) {
+            await backend.deleteFile(sdroot + nroPath);
+            console.debug('hdr-launcher.nro deleted successfully');
+          }
+        }
+      } catch (e) {
+        console.error(`Failed to detect/delete file: ${nroPath}`);
+      }
+
       const str = await backend.readFile(deletions_file);
       const entries = JSON.parse(str);
       let count = 0;
@@ -242,6 +257,7 @@ export async function handleDeletions(
         }
         count += 1;
       }
+
       console.info('done deleting removed files.');
       resolve('done deleting files.');
     } catch (e) {


### PR DESCRIPTION
This is useful for players on PC so they don't have to manually delete the file anytime it shows up, which can sometimes happen when switching between nightly/beta/pr/etc.

Tested on Arch Linux.