### PR TITLE
Make sure config files only live in one place on Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "react-remark": "^2.1.0",
         "react-router-dom": "^6.3.0",
         "react-twitter-embed": "^4.0.4",
-        "request": "^2.88.2"
+        "request": "^2.88.2",
+        "xdg-portable": "^10.6.0"
       },
       "devDependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
@@ -9804,6 +9805,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -14437,6 +14452,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-paths": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-7.4.0.tgz",
+      "integrity": "sha512-Ux1J4NUqC6tZayBqLN1kUlDAEvLiQlli/53sSddU4IN+h+3xxnv2HmRSMpVSvr1hvJzotfMs3ERvETGK+f4OwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "*"
       }
     },
     "node_modules/p-cancelable": {
@@ -19408,6 +19435,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-10.6.0.tgz",
+      "integrity": "sha512-xrcqhWDvtZ7WLmt8G4f3hHy37iK7D2idtosRgkeiSPZEPmBShp0VfmRBLWAPC6zLF48APJ21yfea+RfQMF4/Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^7.4.0"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "*"
       }
     },
     "node_modules/xml-name-validator": {
@@ -26841,6 +26883,12 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -30271,6 +30319,14 @@
         "log-symbols": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "wcwidth": "^1.0.1"
+      }
+    },
+    "os-paths": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-7.4.0.tgz",
+      "integrity": "sha512-Ux1J4NUqC6tZayBqLN1kUlDAEvLiQlli/53sSddU4IN+h+3xxnv2HmRSMpVSvr1hvJzotfMs3ERvETGK+f4OwA==",
+      "requires": {
+        "fsevents": "*"
       }
     },
     "p-cancelable": {
@@ -33935,6 +33991,15 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
+    },
+    "xdg-portable": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-10.6.0.tgz",
+      "integrity": "sha512-xrcqhWDvtZ7WLmt8G4f3hHy37iK7D2idtosRgkeiSPZEPmBShp0VfmRBLWAPC6zLF48APJ21yfea+RfQMF4/Aw==",
+      "requires": {
+        "fsevents": "*",
+        "os-paths": "^7.4.0"
+      }
     },
     "xml-name-validator": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "react-remark": "^2.1.0",
     "react-router-dom": "^6.3.0",
     "react-twitter-embed": "^4.0.4",
-    "request": "^2.88.2"
+    "request": "^2.88.2",
+    "xdg-portable": "^10.6.0"
   },
   "devDependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,4 +1,6 @@
 import * as fs from 'fs';
+import * as os from 'os';
+import xdg from 'xdg-portable';
 
 export default class Config {
   private static CONFIG_FILE = 'launcher-config.json';
@@ -8,12 +10,12 @@ export default class Config {
   sdcardPath: string = '';
 
   private static createFile() {
-    if (!fs.existsSync(Config.CONFIG_FILE)) {
+    if (!fs.existsSync(Config.configFilePath())) {
       const configStr = JSON.stringify({
         ryuPath: null,
         sdcardPath: null,
       });
-      fs.writeFileSync(Config.CONFIG_FILE, configStr);
+      fs.writeFileSync(Config.configFilePath(), configStr);
     }
   }
 
@@ -22,11 +24,11 @@ export default class Config {
     Config.createFile();
 
     // read the file
-    return JSON.parse(fs.readFileSync(Config.CONFIG_FILE, 'utf-8')) as Config;
+    return JSON.parse(fs.readFileSync(Config.configFilePath(), 'utf-8')) as Config;
   }
 
   private static saveConfig(config: Config) {
-    fs.writeFileSync(Config.CONFIG_FILE, JSON.stringify(config));
+    fs.writeFileSync(Config.configFilePath(), JSON.stringify(config));
   }
 
   static getRyuPath() {
@@ -49,6 +51,16 @@ export default class Config {
     const config = Config.readFile();
     config.sdcardPath = path;
     Config.saveConfig(config);
+  }
+
+  // Ensure that the config file only lives in one place on linux
+  // Path is `/home/user/.config/hdr-launcher/launcher-config.json`
+  private static configFilePath() {
+    if (os.platform() == 'linux') {
+      return xdg.config() + '/hdr-launcher/' + this.CONFIG_FILE;
+    }
+
+    return this.CONFIG_FILE;
   }
 
   private constructor() {}


### PR DESCRIPTION
One of the biggest issues with setting up the launcher on Linux is that the app image saves the config file wherever the current working directory is. This can complicate and confuse things when people open the app image from multiple places.

This change ensures that the config file will always live in the canonical XDG config directory `/home/user/.config/hdr-launcher/` no matter where the app image is opened.