### PR TITLE
Fix Seasonal Stagelist Enabled Override

### DIFF
--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hdr-launcher",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hdr-launcher",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "hasInstallScript": true,
       "license": "MIT"
     }

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hdr-launcher",
   "author": "techyCoder81",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "The HDR Launcher",
   "repository": "techyCoder81/hdr-launcher-react",
   "license": "MIT",

--- a/src/renderer/routes/stage_config/stage_config_menu.tsx
+++ b/src/renderer/routes/stage_config/stage_config_menu.tsx
@@ -22,8 +22,10 @@ export default function StageConfigMenu() {
 
     loadConfigData(ACTIVE_CONFIG_FILE)
       .then(async (data) => {
+        let enabled = data.enabled;
         if (data.useOfficial) {
           data = await loadConfigData(OFFICIAL_STAGE_CONFIG);
+          data.enabled = enabled;
         }
         setConfig(data);
       })
@@ -78,8 +80,8 @@ export default function StageConfigMenu() {
                 await save(BACKUP_STAGE_CONFIG, config);
                 loadConfigData(OFFICIAL_STAGE_CONFIG).then(async (data) => {
                   const newConfig = new ConfigData(
-                    data.enabled,
-                    data.useOfficial,
+                    config.enabled,
+                    true,
                     data.starters,
                     data.counterpicks
                   );
@@ -91,7 +93,7 @@ export default function StageConfigMenu() {
                 // load the stagelist from the backup file
                 loadConfigData(BACKUP_STAGE_CONFIG).then(async (data) => {
                   const newConfig = new ConfigData(
-                    data.enabled,
+                    config.enabled,
                     false,
                     data.starters,
                     data.counterpicks

--- a/switch/Cargo.lock
+++ b/switch/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "hdr-launcher-react"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "arcropolis-api",

--- a/switch/Cargo.toml
+++ b/switch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdr-launcher-react"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["techyCoder81"]
 edition = "2021"
 


### PR DESCRIPTION
toggling Use Seasonal Stagelist will no longer manipulate whether or not tourney stage config is enabled

version 0.7.0 -> 0.7.1