### PR TITLE
update tourney config button layout

### DIFF
--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hdr-launcher",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hdr-launcher",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "hasInstallScript": true,
       "license": "MIT"
     }

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hdr-launcher",
   "author": "techyCoder81",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "The HDR Launcher",
   "repository": "techyCoder81/hdr-launcher-react",
   "license": "MIT",

--- a/src/renderer/routes/stage_config/stage_config_menu.tsx
+++ b/src/renderer/routes/stage_config/stage_config_menu.tsx
@@ -62,31 +62,6 @@ export default function StageConfigMenu() {
   return (
     <FullScreenDiv>
       <div id="header-bar" className="border-bottom" style={{}}>
-        <FocusButton
-          text="Cancel"
-          onClick={() => {
-            setInitialized(false);
-            navigate(Pages.MAIN_MENU);
-          }}
-          className="simple-button-bigger"
-          onFocus={() => {}}
-          autofocus
-          style={{margin: "4px 2px 4px 4px"}}
-        />
-        {initialized ? (
-          <FocusButton
-            text="Reset"
-            onClick={() => {
-              setInitialized(false);
-            }}
-            className="simple-button-bigger"
-            onFocus={() => {}}
-            autofocus
-          style={{margin: "4px 2px 4px 4px"}}
-          />
-        ) : (
-          <div />
-        )}
         {initialized ? (
           <FocusButton
             text="Save & Exit"
@@ -106,9 +81,33 @@ export default function StageConfigMenu() {
           style={{margin: "4px 2px 4px 4px"}}
           />
         ) : (
-          <div />
+          <FocusButton
+            text="Cancel"
+            onClick={() => {
+              setInitialized(false);
+              navigate(Pages.MAIN_MENU);
+            }}
+            className="simple-button-bigger"
+            onFocus={() => {}}
+            autofocus
+            style={{margin: "4px 2px 4px 4px"}}
+          />
         )}
         <StageConfigToggler />
+        {initialized ? (
+          <FocusButton
+            text="Reset"
+            onClick={() => {
+              setInitialized(false);
+            }}
+            className="simple-button-bigger"
+            onFocus={() => {}}
+            autofocus
+          style={{margin: "4px 2px 4px 4px"}}
+          />
+        ) : (
+          <div />
+        )}
       </div>
       {initialized && stages ? (
         <div id="main-content" className="stage-config-body">

--- a/switch/Cargo.lock
+++ b/switch/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "hdr-launcher-react"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "arcropolis-api",

--- a/switch/Cargo.toml
+++ b/switch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdr-launcher-react"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["techyCoder81"]
 edition = "2021"
 


### PR DESCRIPTION
Removes the "Cancel" button from Tourney Config. Moves "Save & Exit" to the left and moves "Reset" all the way to the right.