### PR TITLE
Automatically delete launcher nro file if running on PC/Emulator

### DIFF
--- a/.erb/configs/webpack.config.base.ts
+++ b/.erb/configs/webpack.config.base.ts
@@ -44,6 +44,9 @@ const configuration: webpack.Configuration = {
    * Determine the array of extensions that should be used to resolve modules.
    */
   resolve: {
+    fallback: {
+      "path": require.resolve("path-browserify")
+    },
     extensions: ['.js', '.jsx', '.json', '.ts', '.tsx'],
     modules: [webpackPaths.srcPath, 'node_modules'],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "md5-file": "^5.0.0",
         "nx-request-api": "^0.1.21",
         "open-file-explorer": "^1.0.2",
+        "path-browserify": "^1.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-modal": "^3.16.1",
@@ -3761,7 +3762,8 @@
       "version": "18.7.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
       "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -14817,6 +14819,12 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -30606,6 +30614,11 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "path-exists": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "md5-file": "^5.0.0",
     "nx-request-api": "^0.1.21",
     "open-file-explorer": "^1.0.2",
+    "path-browserify": "^1.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-modal": "^3.16.1",

--- a/src/renderer/operations/update.ts
+++ b/src/renderer/operations/update.ts
@@ -1,6 +1,7 @@
 import { Progress } from 'nx-request-api';
 import { Backend } from './backend';
 import { getInstallType, getRepoName } from './install';
+import path from 'path';
 
 export async function isAvailable(
   progressCallback?: (p: Progress) => void
@@ -206,7 +207,7 @@ export async function handleDeletions(
 
       // check for hdr-launcher.nro and delete it if we're on emulator
       const platform = await backend.getPlatform();
-      const nroPath = 'atmosphere/contents/01006A800016E000/romfs/skyline/plugins/hdr-launcher.nro';
+      const nroPath = path.join('atmosphere', 'contents', '01006A800016E000', 'romfs', 'skyline', 'plugins', 'hdr-launcher.nro');
       try {
         if (platform === "Emulator") {
           const exists = await backend.fileExists(sdroot + nroPath);

--- a/src/renderer/operations/update.ts
+++ b/src/renderer/operations/update.ts
@@ -204,6 +204,21 @@ export async function handleDeletions(
         (p: Progress) => reportProgress(p)
       );
 
+      // check for hdr-launcher.nro and delete it if we're on emulator
+      const platform = await backend.getPlatform();
+      const nroPath = 'atmosphere/contents/01006A800016E000/romfs/skyline/plugins/hdr-launcher.nro';
+      try {
+        if (platform === "Emulator") {
+          const exists = await backend.fileExists(sdroot + nroPath);
+          if (exists) {
+            await backend.deleteFile(sdroot + nroPath);
+            console.debug('hdr-launcher.nro deleted successfully');
+          }
+        }
+      } catch (e) {
+        console.error(`Failed to detect/delete file: ${nroPath}`);
+      }
+
       const str = await backend.readFile(deletions_file);
       const entries = JSON.parse(str);
       let count = 0;
@@ -242,6 +257,7 @@ export async function handleDeletions(
         }
         count += 1;
       }
+
       console.info('done deleting removed files.');
       resolve('done deleting files.');
     } catch (e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7988,6 +7988,11 @@ pascal-case@^3.1.2:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"


### PR DESCRIPTION
This is useful for players on certain emulators so they don't have to manually delete the file anytime it shows up, which can sometimes happen when switching between nightly/beta/pr/etc.

Tested on Arch Linux.
