### PR TITLE
Add launcher reset to File menu

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -33,6 +33,22 @@ export default class Config {
     fs.writeFileSync(Config.configFilePath(), JSON.stringify(config));
   }
 
+  static resetConfig() {
+    const configPath = Config.configFilePath();
+    if (!fs.existsSync(configPath)) {
+      return;
+    }
+
+    let backupPath = `${configPath}.bak`;
+    let index = 1;
+    while (fs.existsSync(backupPath)) {
+      backupPath = `${configPath}.bak${index}`;
+      index += 1;
+    }
+
+    fs.renameSync(configPath, backupPath);
+  }
+
   static getRyuPath() {
     const config = Config.readFile();
     return config.ryuPath;

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -5,6 +5,7 @@ import {
   BrowserWindow,
   MenuItemConstructorOptions,
 } from 'electron';
+import Config from './config';
 
 interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions {
   selector?: string;
@@ -198,8 +199,15 @@ export default class MenuBuilder {
         label: '&File',
         submenu: [
           {
-            label: '&Open',
-            accelerator: 'Ctrl+O',
+            label: '&Reset Launcher Config',
+            click: () => {
+              Config.resetConfig();
+              app.relaunch();
+              app.quit();
+            },
+          },
+          {
+            type: 'separator',
           },
           {
             label: '&Close',


### PR DESCRIPTION
Useful for when people move their emulator, which happens surprisingly often, for some reason.