### PR TITLE
Fix paths with spaces on Linux and macOS

### DIFF
--- a/src/main/request_handler.ts
+++ b/src/main/request_handler.ts
@@ -815,7 +815,7 @@ async function handleInner(
     case 'exit_session':
       // play the game
       // resolve(new Responses.OkOrError(true, "starting the game...", request.id));
-      let command = path.normalize(`${Config.getRyuPath()}`);
+      let command = `"${path.normalize(Config.getRyuPath())}"`;
       if (process.platform == 'win32') {
         command = `cmd /C ""${Config.getRyuPath()}""`;
       }


### PR DESCRIPTION
On Linux and macOS, the emulator path isn't quoted, which means that when there are spaces in any of the folder names in the full path of the emulator, it doesn't launch. 

Fixed by quoting the path.